### PR TITLE
Add FreeBSD CI Github Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,173 @@
+name: LWJGL Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+env:
+  AWS_DEFAULT_REGION: us-east-1
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  S3_PARAMS: --acl public-read --cache-control "public,must-revalidate,proxy-revalidate,max-age=0"
+  ANT_OPTS: -Xmx1G
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ARCH: [x64, arm32, arm64]
+        include:
+          - ARCH: x64
+            PACKAGES: gcc-4.8 g++-4.8 gcc-4.9 g++-4.9 xorg-dev libgtk-3-dev libglu-dev libgl1-mesa-glx libx11-dev
+            NATIVE_PARAMS: -Dgcc.libpath.opengl=/usr/lib/x86_64-linux-gnu/mesa
+          - ARCH: arm32
+            PACKAGES: gcc-4.8-arm-linux-gnueabihf g++-4.8-arm-linux-gnueabihf gcc-4.9-arm-linux-gnueabihf g++-4.9-arm-linux-gnueabihf libc6-dev-armhf-cross
+            CROSS_ARCH: armhf
+            CROSS_PACKAGES: libgtk-3-dev:armhf libglu-dev:armhf libgl1-mesa-glx:armhf libx11-dev:armhf
+            NATIVE_PARAMS: -Dgcc.libpath.opengl=/usr/lib/arm-linux-gnueabihf/mesa
+          - ARCH: arm64
+            PACKAGES: gcc-4.8-aarch64-linux-gnu g++-4.8-aarch64-linux-gnu gcc-4.9-aarch64-linux-gnu g++-4.9-aarch64-linux-gnu libc6-dev-arm64-cross
+            CROSS_ARCH: arm64
+            CROSS_PACKAGES: libgtk-3-dev:arm64 libglu-dev:arm64 libgl1-mesa-glx:arm64 libx11-dev:arm64
+            NATIVE_PARAMS: -Dgcc.libpath.opengl=/usr/lib/aarch64-linux-gnu/mesa
+    env:
+      JAVA_HOME: jdk8
+      LWJGL_BUILD_TYPE: nightly
+      LWJGL_BUILD_ARCH: ${{matrix.ARCH}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 3
+      - run: |
+          sudo apt-get update
+          sudo apt-get -yq install ${{matrix.PACKAGES}}
+          curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
+          mkdir jdk8
+          tar xf jdk8.tar.gz -C jdk8 --strip-components 1
+        name: Install dependencies
+      - run: |
+          if [[ "${{matrix.ARCH}}" != "mips64" ]]
+          then
+            sudo sed -i 's/deb http/deb [arch=amd64,i386] http/' /etc/apt/sources.list
+            sudo grep "ubuntu.com/ubuntu" /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/ports.list
+            sudo sed -i 's/amd64,i386/armhf,arm64/' /etc/apt/sources.list.d/ports.list
+            sudo sed -i 's#http://.*/ubuntu#http://ports.ubuntu.com/ubuntu-ports#' /etc/apt/sources.list.d/ports.list
+          else
+            sudo apt-get -yq install gcc-5-mips64el-linux-gnuabi64 libc6-dev-mips64el-cross
+            sudo rm -rf /etc/apt/sources.list
+            sudo sh -c "echo 'deb http://deb.debian.org/debian buster main' >> /etc/apt/sources.list"
+          fi
+          sudo dpkg --add-architecture ${{matrix.CROSS_ARCH}}
+          sudo apt-get clean
+          sudo apt-get update || true
+        if: contains(matrix.ARCH, 'x64') != true
+        name: Prepare cross-compilation
+      - run: sudo apt-get -yq -f --allow-unauthenticated --no-install-suggests --no-install-recommends install ${{matrix.CROSS_PACKAGES}} -o Dpkg::Options::="--force-overwrite"
+        if: contains(matrix.ARCH, 'x64') != true
+        name: Install cross-compilation dependencies
+      - run: ant -emacs hydrate-kotlinc clean-generated generate
+        name: Hydrate generator
+      - run: ant -emacs compile
+        name: Build Java
+      - run: ant -emacs compile-native -Dgcc.version=4.8 ${{matrix.NATIVE_PARAMS}}
+        name: Build native
+      - run: ant -emacs tests
+        name: Run tests
+        if: contains(matrix.ARCH, 'x64')
+      - run: ant -emacs upload-native
+        name: Upload artifacts
+
+  macos:
+    name: macOS
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ARCH: [x64, arm64]
+        include:
+          - ARCH: x64
+            SDK_ROOT:
+          - ARCH: arm64
+            SDK_ROOT: SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
+    env:
+      JAVA_HOME: jdk8
+      LWJGL_BUILD_TYPE: nightly
+      LWJGL_BUILD_ARCH: ${{matrix.ARCH}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 3
+      - run: |
+          curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-macosx_x64.tar.gz --output jdk8.tar.gz
+          mkdir jdk8
+          tar xf jdk8.tar.gz -C jdk8 --strip-components 1
+        name: Install dependencies
+      - run: ant -emacs hydrate-kotlinc clean-generated generate
+        name: Hydrate generator
+      - run: ant -emacs compile
+        name: Build Java
+      - run: ${{matrix.SDK_ROOT}} ant -emacs compile-native
+        name: Build native
+      - run: ant -emacs tests
+        name: Run tests
+        if: contains(matrix.ARCH, 'arm') != true
+      - run: ant -emacs upload-native
+        name: Upload artifacts
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ARCH: [x86, x64, arm64]
+        include:
+          - ARCH: x86
+            JDK: zulu8.52.0.23-ca-fx-jdk8.0.282-win_i686
+            MSVC_ARCH: amd64_x86
+          - ARCH: x64
+            JDK: zulu8.52.0.23-ca-fx-jdk8.0.282-win_x64
+            MSVC_ARCH: amd64
+          - ARCH: arm64
+            JDK: zulu8.52.0.23-ca-fx-jdk8.0.282-win_x64
+            MSVC_ARCH: amd64_arm64
+    env:
+      JAVA_HOME: ${{matrix.JDK}}
+      LWJGL_BUILD_TYPE: nightly
+      LWJGL_BUILD_ARCH: ${{matrix.ARCH}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 3
+      - run: |
+          git clone https://github.com/LWJGL-CI/OculusSDK.git ../OculusSDK
+          Invoke-WebRequest https://cdn.azul.com/zulu/bin/${{matrix.JDK}}.zip -OutFile jdk.zip
+          Expand-Archive -Path jdk.zip -DestinationPath .\
+        name: Install dependencies
+      - run: ant -emacs hydrate-kotlinc clean-generated generate
+        shell: cmd
+        name: Generate bindings
+      - run: ant -emacs compile
+        shell: cmd
+        name: Build Java
+      - run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{matrix.MSVC_ARCH}}
+          ant -emacs compile-native
+        shell: cmd
+        name: Build native
+      - run: ant -emacs tests
+        shell: cmd
+        if: contains(matrix.ARCH, 'arm') != true
+        name: Run tests
+      - run: type bin\test\testng-results.xml
+        shell: cmd
+        if: failure()
+        name: Print test results
+      - run: ant -emacs upload-native
+        shell: cmd
+        name: Upload artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,7 +136,7 @@ jobs:
           mem: 4096
           envs: 'LWJGL_BUILD_TYPE LWJGL_BUILD_ARCH'
           prepare: |
-            pkg install -y apache-ant
+            pkg install -y apache-ant git
             mount -t fdescfs fdesc /dev/fd
             mount -t procfs proc /proc
           run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -146,7 +146,6 @@ jobs:
 #            curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
 #            mkdir jdk8
 #            tar xf jdk8.tar.gz -C jdk8 --strip-components 1
-
             ant -emacs hydrate-kotlinc clean-generated generate
             ant -emacs compile
 #            ant -emacs compile-native -Dgcc.version=4.8 ${{matrix.NATIVE_PARAMS}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,7 +136,7 @@ jobs:
           mem: 4096
           envs: 'LWJGL_BUILD_TYPE LWJGL_BUILD_ARCH'
           prepare: |
-            pkg install -y apache-ant git
+            pkg install -y apache-ant git cmake libX11 libXrandr libXinerama libXcursor xinput dyncall
             mount -t fdescfs fdesc /dev/fd
             mount -t procfs proc /proc
           run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,7 +135,8 @@ jobs:
           usesh: true
           mem: 4096
           envs: 'LWJGL_BUILD_TYPE LWJGL_BUILD_ARCH'
-          prepare: pkg install -y apache-ant
+          prepare: |
+            pkg install -y apache-ant
             mount -t fdescfs fdesc /dev/fd
             mount -t procfs proc /proc
           run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -119,6 +119,66 @@ jobs:
       - run: ant -emacs upload-native
         name: Upload artifacts
 
+  freebsd:
+    name: FreeBSD
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ARCH: [x64, arm64]
+        include:
+          - ARCH: x64
+            PACKAGES: gcc-4.8 g++-4.8 gcc-4.9 g++-4.9 xorg-dev libgtk-3-dev libglu-dev libgl1-mesa-glx libx11-dev
+            NATIVE_PARAMS: -Dgcc.libpath.opengl=/usr/lib/x86_64-linux-gnu/mesa
+          - ARCH: arm64
+            PACKAGES: gcc-4.8-aarch64-linux-gnu g++-4.8-aarch64-linux-gnu gcc-4.9-aarch64-linux-gnu g++-4.9-aarch64-linux-gnu libc6-dev-arm64-cross
+            CROSS_ARCH: arm64
+            CROSS_PACKAGES: libgtk-3-dev:arm64 libglu-dev:arm64 libgl1-mesa-glx:arm64 libx11-dev:arm64
+            NATIVE_PARAMS: -Dgcc.libpath.opengl=/usr/lib/aarch64-linux-gnu/mesa
+    env:
+      JAVA_HOME: jdk8
+      LWJGL_BUILD_TYPE: nightly
+      LWJGL_BUILD_ARCH: ${{matrix.ARCH}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 3
+      - uses: vmactions/freebsd-vm@v0.1.2
+        usesh: true
+        prepare: pkg install -y curl
+      - run: |
+          freebsd-version
+          sudo apt-get update
+          sudo apt-get -yq install ${{matrix.PACKAGES}}
+          curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
+          mkdir jdk8
+          tar xf jdk8.tar.gz -C jdk8 --strip-components 1
+        name: Install dependencies
+      - run: |
+          sudo sed -i 's/deb http/deb [arch=amd64,i386] http/' /etc/apt/sources.list
+          sudo grep "ubuntu.com/ubuntu" /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/ports.list
+          sudo sed -i 's/amd64,i386/armhf,arm64/' /etc/apt/sources.list.d/ports.list
+          sudo sed -i 's#http://.*/ubuntu#http://ports.ubuntu.com/ubuntu-ports#' /etc/apt/sources.list.d/ports.list
+          sudo dpkg --add-architecture ${{matrix.CROSS_ARCH}}
+          sudo apt-get clean
+          sudo apt-get update || true
+        if: contains(matrix.ARCH, 'x64') != true
+        name: Prepare cross-compilation
+      - run: sudo apt-get -yq -f --allow-unauthenticated --no-install-suggests --no-install-recommends install ${{matrix.CROSS_PACKAGES}} -o Dpkg::Options::="--force-overwrite"
+        if: contains(matrix.ARCH, 'x64') != true
+        name: Install cross-compilation dependencies
+      - run: ant -emacs hydrate-kotlinc clean-generated generate
+        name: Hydrate generator
+      - run: ant -emacs compile
+        name: Build Java
+      - run: ant -emacs compile-native -Dgcc.version=4.8 ${{matrix.NATIVE_PARAMS}}
+        name: Build native
+      - run: ant -emacs tests
+        name: Run tests
+#        if: contains(matrix.ARCH, 'x64')
+#      - run: ant -emacs upload-native
+#        name: Upload artifacts
+
   windows:
     name: Windows
     runs-on: windows-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           fetch-depth: 3
       - uses: vmactions/freebsd-vm@v0.1.3
-        name: Install dependencies
+        name: Build on FreeBSD
         with:
           usesh: true
           mem: 4096
@@ -140,18 +140,11 @@ jobs:
             mount -t fdescfs fdesc /dev/fd
             mount -t procfs proc /proc
           run: |
-            pwd
-            ls -lah
-            whoami
-            env
-            freebsd-version
             ant -emacs hydrate-kotlinc clean-generated generate
             ant -emacs compile
             ant -emacs compile-native
             ant -emacs tests
-
-#            xorg gtk3 libGLU mesa-libs libX11
-#            ant -emacs upload-native
+            ant -emacs upload-native
 
   windows:
     name: Windows

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,6 +148,7 @@ jobs:
           usesh: true
           prepare: pkg install -y curl
       - run: |
+          usesh: true
           freebsd-version
           sudo apt-get update
           sudo apt-get -yq install ${{matrix.PACKAGES}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -140,11 +140,11 @@ jobs:
             mount -t fdescfs fdesc /dev/fd
             mount -t procfs proc /proc
           run: |
-            ant -emacs hydrate-kotlinc clean-generated generate
-            ant -emacs compile
-            ant -emacs compile-native
-            ant -emacs tests
-            ant -emacs upload-native
+            ant -emacs -Dplatform=freebsd hydrate-kotlinc clean-generated generate
+            ant -emacs -Dplatform=freebsd compile
+            ant -emacs -Dplatform=freebsd compile-native
+            ant -emacs -Dplatform=freebsd tests
+            ant -emacs -Dplatform=freebsd upload-native
 
   windows:
     name: Windows

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           usesh: true
           mem: 4096
-          # xorg gtk3 libGLU mesa-libs libX11
+          envs: 'JAVA_HOME LWJGL_BUILD_TYPE LWJGL_BUILD_ARCH'
           prepare: pkg install -y curl
           run: |
             pwd
@@ -143,14 +143,12 @@ jobs:
             whoami
             env
             freebsd-version
-#            curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
-#            mkdir jdk8
-#            tar xf jdk8.tar.gz -C jdk8 --strip-components 1
             ant -emacs hydrate-kotlinc clean-generated generate
             ant -emacs compile
-#            ant -emacs compile-native -Dgcc.version=4.8 ${{matrix.NATIVE_PARAMS}}
             ant -emacs compile-native
             ant -emacs tests
+
+#            xorg gtk3 libGLU mesa-libs libX11
 #            ant -emacs upload-native
 
   windows:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -123,7 +123,6 @@ jobs:
     name: FreeBSD (x64)
     runs-on: macos-latest
     env:
-      JAVA_HOME: jdk8
       LWJGL_BUILD_TYPE: nightly
       LWJGL_BUILD_ARCH: x64
     steps:
@@ -135,8 +134,10 @@ jobs:
         with:
           usesh: true
           mem: 4096
-          envs: 'JAVA_HOME LWJGL_BUILD_TYPE LWJGL_BUILD_ARCH'
+          envs: 'LWJGL_BUILD_TYPE LWJGL_BUILD_ARCH'
           prepare: pkg install -y apache-ant
+            mount -t fdescfs fdesc /dev/fd
+            mount -t procfs proc /proc
           run: |
             pwd
             ls -lah

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,7 +143,7 @@ jobs:
         with:
           usesh: true
           prepare: pkg install -y curl
-        - run: |
+          run: |
             pwd
             ls -lah
             whoami

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,16 +125,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ARCH: [x64, arm64]
+        ARCH: [x64]
         include:
           - ARCH: x64
-            PACKAGES: gcc-4.8 g++-4.8 gcc-4.9 g++-4.9 xorg-dev libgtk-3-dev libglu-dev libgl1-mesa-glx libx11-dev
-            NATIVE_PARAMS: -Dgcc.libpath.opengl=/usr/lib/x86_64-linux-gnu/mesa
-          - ARCH: arm64
-            PACKAGES: gcc-4.8-aarch64-linux-gnu g++-4.8-aarch64-linux-gnu gcc-4.9-aarch64-linux-gnu g++-4.9-aarch64-linux-gnu libc6-dev-arm64-cross
-            CROSS_ARCH: arm64
-            CROSS_PACKAGES: libgtk-3-dev:arm64 libglu-dev:arm64 libgl1-mesa-glx:arm64 libx11-dev:arm64
-            NATIVE_PARAMS: -Dgcc.libpath.opengl=/usr/lib/aarch64-linux-gnu/mesa
+            PACKAGES: xorg gtk3 libGLU mesa-libs libX11
+            NATIVE_PARAMS:
+                #            NATIVE_PARAMS: -Dgcc.libpath.opengl=/usr/lib/x86_64-linux-gnu/mesa
     env:
       JAVA_HOME: jdk8
       LWJGL_BUILD_TYPE: nightly
@@ -156,19 +152,6 @@ jobs:
           mkdir jdk8
           tar xf jdk8.tar.gz -C jdk8 --strip-components 1
         name: Install dependencies
-      - run: |
-          sudo sed -i 's/deb http/deb [arch=amd64,i386] http/' /etc/apt/sources.list
-          sudo grep "ubuntu.com/ubuntu" /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/ports.list
-          sudo sed -i 's/amd64,i386/armhf,arm64/' /etc/apt/sources.list.d/ports.list
-          sudo sed -i 's#http://.*/ubuntu#http://ports.ubuntu.com/ubuntu-ports#' /etc/apt/sources.list.d/ports.list
-          sudo dpkg --add-architecture ${{matrix.CROSS_ARCH}}
-          sudo apt-get clean
-          sudo apt-get update || true
-        if: contains(matrix.ARCH, 'x64') != true
-        name: Prepare cross-compilation
-      - run: sudo apt-get -yq -f --allow-unauthenticated --no-install-suggests --no-install-recommends install ${{matrix.CROSS_PACKAGES}} -o Dpkg::Options::="--force-overwrite"
-        if: contains(matrix.ARCH, 'x64') != true
-        name: Install cross-compilation dependencies
       - run: ant -emacs hydrate-kotlinc clean-generated generate
         name: Hydrate generator
       - run: ant -emacs compile
@@ -177,7 +160,6 @@ jobs:
         name: Build native
       - run: ant -emacs tests
         name: Run tests
-#        if: contains(matrix.ARCH, 'x64')
 #      - run: ant -emacs upload-native
 #        name: Upload artifacts
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -144,8 +144,9 @@ jobs:
         with:
           fetch-depth: 3
       - uses: vmactions/freebsd-vm@v0.1.2
-        usesh: true
-        prepare: pkg install -y curl
+        with:
+          usesh: true
+          prepare: pkg install -y curl
       - run: |
           freebsd-version
           sudo apt-get update

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -120,7 +120,7 @@ jobs:
         name: Upload artifacts
 
   freebsd:
-    name: FreeBSD
+    name: FreeBSD (x64)
     runs-on: macos-latest
     env:
       JAVA_HOME: jdk8
@@ -136,7 +136,7 @@ jobs:
           usesh: true
           mem: 4096
           envs: 'JAVA_HOME LWJGL_BUILD_TYPE LWJGL_BUILD_ARCH'
-          prepare: pkg install -y curl
+          prepare: pkg install -y apache-ant
           run: |
             pwd
             ls -lah

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,14 +143,17 @@ jobs:
         with:
           usesh: true
           prepare: pkg install -y curl
-      - run: |
-          usesh: true
-          freebsd-version
-          sudo apt-get update
-          sudo apt-get -yq install ${{matrix.PACKAGES}}
-          curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
-          mkdir jdk8
-          tar xf jdk8.tar.gz -C jdk8 --strip-components 1
+        - run: |
+            pwd
+            ls -lah
+            whoami
+            env
+            freebsd-version
+            sudo apt-get update
+            sudo apt-get -yq install ${{matrix.PACKAGES}}
+            curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
+            mkdir jdk8
+            tar xf jdk8.tar.gz -C jdk8 --strip-components 1
         name: Install dependencies
       - run: ant -emacs hydrate-kotlinc clean-generated generate
         name: Hydrate generator

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -122,19 +122,10 @@ jobs:
   freebsd:
     name: FreeBSD
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ARCH: [x64]
-        include:
-          - ARCH: x64
-            PACKAGES: xorg gtk3 libGLU mesa-libs libX11
-            NATIVE_PARAMS:
-                #            NATIVE_PARAMS: -Dgcc.libpath.opengl=/usr/lib/x86_64-linux-gnu/mesa
     env:
       JAVA_HOME: jdk8
       LWJGL_BUILD_TYPE: nightly
-      LWJGL_BUILD_ARCH: ${{matrix.ARCH}}
+      LWJGL_BUILD_ARCH: x64
     steps:
       - uses: actions/checkout@v2
         with:
@@ -144,6 +135,7 @@ jobs:
         with:
           usesh: true
           mem: 4096
+          # xorg gtk3 libGLU mesa-libs libX11
           prepare: pkg install -y curl
           run: |
             pwd
@@ -151,21 +143,16 @@ jobs:
             whoami
             env
             freebsd-version
-            sudo apt-get update
-            sudo apt-get -yq install ${{matrix.PACKAGES}}
-            curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
-            mkdir jdk8
-            tar xf jdk8.tar.gz -C jdk8 --strip-components 1
-          run: ant -emacs hydrate-kotlinc clean-generated generate
-            name: Hydrate generator
-      - run: ant -emacs compile
-        name: Build Java
-      - run: ant -emacs compile-native -Dgcc.version=4.8 ${{matrix.NATIVE_PARAMS}}
-        name: Build native
-      - run: ant -emacs tests
-        name: Run tests
-#      - run: ant -emacs upload-native
-#        name: Upload artifacts
+#            curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
+#            mkdir jdk8
+#            tar xf jdk8.tar.gz -C jdk8 --strip-components 1
+
+            ant -emacs hydrate-kotlinc clean-generated generate
+            ant -emacs compile
+#            ant -emacs compile-native -Dgcc.version=4.8 ${{matrix.NATIVE_PARAMS}}
+            ant -emacs compile-native
+            ant -emacs tests
+#            ant -emacs upload-native
 
   windows:
     name: Windows

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -140,8 +140,10 @@ jobs:
         with:
           fetch-depth: 3
       - uses: vmactions/freebsd-vm@v0.1.3
+        name: Install dependencies
         with:
           usesh: true
+          mem: 4096
           prepare: pkg install -y curl
           run: |
             pwd
@@ -154,9 +156,8 @@ jobs:
             curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
             mkdir jdk8
             tar xf jdk8.tar.gz -C jdk8 --strip-components 1
-        name: Install dependencies
-      - run: ant -emacs hydrate-kotlinc clean-generated generate
-        name: Hydrate generator
+          - run: ant -emacs hydrate-kotlinc clean-generated generate
+              name: Hydrate generator
       - run: ant -emacs compile
         name: Build Java
       - run: ant -emacs compile-native -Dgcc.version=4.8 ${{matrix.NATIVE_PARAMS}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 3
-      - uses: vmactions/freebsd-vm@v0.1.3
+      - uses: vmactions/freebsd-vm@v0.1.4
         name: Build on FreeBSD
         with:
           usesh: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -156,8 +156,8 @@ jobs:
             curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
             mkdir jdk8
             tar xf jdk8.tar.gz -C jdk8 --strip-components 1
-          - run: ant -emacs hydrate-kotlinc clean-generated generate
-              name: Hydrate generator
+          run: ant -emacs hydrate-kotlinc clean-generated generate
+            name: Hydrate generator
       - run: ant -emacs compile
         name: Build Java
       - run: ant -emacs compile-native -Dgcc.version=4.8 ${{matrix.NATIVE_PARAMS}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 3
-      - uses: vmactions/freebsd-vm@v0.1.2
+      - uses: vmactions/freebsd-vm@v0.1.3
         with:
           usesh: true
           prepare: pkg install -y curl

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,40 @@
+# Generates javadoc for core + all bindings and uploads it to S3.
+# The resulting javadoc is available at https://javadoc.lwjgl.org/
+name: LWJGL Javadoc generation
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_DEFAULT_REGION: us-east-1
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  S3_PARAMS: --acl public-read --cache-control "public,must-revalidate,proxy-revalidate,max-age=0"
+  ANT_OPTS: -Xmx2G
+  LWJGL_BUILD_TYPE: nightly
+
+jobs:
+  linux:
+    name: Javadoc
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 3
+      - run: |
+          git clone https://github.com/LWJGL-CI/OculusSDK.git ../OculusSDK
+          curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
+          curl https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-linux_x64.tar.gz --output jdk10.tar.gz
+          mkdir jdk8
+          mkdir jdk10
+          tar xf jdk8.tar.gz -C jdk8 --strip-components 1
+          tar xf jdk10.tar.gz -C jdk10 --strip-components 1
+        name: Install dependencies
+      - run: JAVA_HOME=$(pwd)/jdk8 ant -emacs hydrate-kotlinc clean-generated generate
+        name: Generate bindings
+      - run: JAVA_HOME=$(pwd)/jdk8 ant -emacs compile
+        name: Build Java
+      - run: JAVA_HOME=$(pwd)/jdk10 ant -emacs javadoc
+        name: Generate javadoc
+      - run: aws s3 sync bin/javadoc s3://javadoc.lwjgl.org/ --delete
+        name: Upload javadoc to S3

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,58 @@
+# Produces a new build, uploads it to S3 and publishes a Maven snapshot
+name: LWJGL Snapshot
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_DEFAULT_REGION: us-east-1
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  S3_PARAMS: --acl public-read --cache-control "public,must-revalidate,proxy-revalidate,max-age=0"
+  ANT_OPTS: -Xmx2G
+  LWJGL_BUILD_TYPE: nightly
+
+jobs:
+  linux:
+    name: Snapshot
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 3
+      - run: |
+          aws s3 cp s3://build.lwjgl.org/ci/next-build.txt .
+          LWJGL_BUILD=$(cat next-build.txt)
+          echo "LWJGL_BUILD=$LWJGL_BUILD" >> $GITHUB_ENV
+        name: Retrieve build number
+      - run: |
+          git clone https://github.com/LWJGL-CI/OculusSDK.git ../OculusSDK
+          curl https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-fx-jdk8.0.282-linux_x64.tar.gz --output jdk8.tar.gz
+          curl https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-linux_x64.tar.gz --output jdk10.tar.gz
+          mkdir jdk8
+          mkdir jdk10
+          tar xf jdk8.tar.gz -C jdk8 --strip-components 1
+          tar xf jdk10.tar.gz -C jdk10 --strip-components 1
+        name: Install dependencies
+      - run: JAVA_HOME=$(pwd)/jdk8 ant -emacs hydrate-kotlinc clean-generated generate
+        name: Generate bindings
+      - run: JAVA_HOME=$(pwd)/jdk8 ant -emacs compile
+        name: Build Java
+      - run: |
+          export JAVA_HOME=$(pwd)/jdk10
+          JAVA8_HOME=$(pwd)/jdk8 ant -emacs release -Dbuild.revision=${{env.LWJGL_BUILD}}
+          $JAVA_HOME/bin/jar cfM lwjgl.zip -C bin/RELEASE .
+        name: "Package snapshot #${{env.LWJGL_BUILD}}"
+      - run: |
+          aws s3 cp lwjgl.zip s3://build.lwjgl.org/nightly/lwjgl.zip $S3_PARAMS
+          aws s3 sync bin/RELEASE s3://build.lwjgl.org/nightly/bin --delete $S3_PARAMS
+        name: Upload snapshot to S3
+      - run: |
+          export JAVA_HOME=$(pwd)/jdk8
+          ./gradlew -Psnapshot -PsonatypeUsername=${{ secrets.SONATYPE_USER }} -PsonatypePassword=${{ secrets.SONATYPE_PWD }} publish
+        name: Publish snapshot to Maven
+      - run: |
+          echo -n $((LWJGL_BUILD+1)) > next-build.txt
+          echo "Next build will be #$(cat next-build.txt)"
+          aws s3 cp next-build.txt s3://build.lwjgl.org/ci/
+        name: Bump build number

--- a/build.xml
+++ b/build.xml
@@ -1307,6 +1307,7 @@
                 public="true"
                 maxmemory="1G"
                 failonerror="true"
+                verbose="true"
                 unless:set="javadoc.skip"
             >
                 <doctitle><![CDATA[<h1>LWJGL - @{title}</h1>]]></doctitle>
@@ -1416,8 +1417,6 @@
         >
             <arg value="${module.list}"/>
         </java>
-
-        <parallel threadcount="4" failonany="true">
 
         <!-- CORE -->
         <sequential>
@@ -1696,7 +1695,5 @@
 
         <!-- zstd -->
         <release-module name="zstd" native-library="lwjgl_zstd" title="zstd" if:true="${binding.zstd}"/>
-
-        </parallel>
     </target>
 </project>


### PR DESCRIPTION
This PR adds working Github Actions for FreeBSD build.

It still needs to add ant build configurations for FreeBSD.

If you need to install additional packages for building, add it to the end of pkg install command.

Related issue is here:
https://github.com/LWJGL/lwjgl3/issues/421

Here is CI output:
https://github.com/ivan-volnov/lwjgl3/runs/2426090932?check_suite_focus=true

It shows ant error because there is no such build configuration for FreeBSD:

```
Buildfile: /Users/runner/work/lwjgl3/lwjgl3/build.xml

BUILD FAILED
/Users/runner/work/lwjgl3/lwjgl3/build.xml:13: Cannot find /Users/runner/work/lwjgl3/lwjgl3/config/${platform}/build.xml imported from /Users/runner/work/lwjgl3/lwjgl3/build.xml

Total time: 1 second
```

It seems it also needs openjfx14 because we don't use zulu here. But I have no idea how to patch build system for openjfx14

But I suppose build configurations should be PR'ed to the main repo instead.

So this PR is complete for now